### PR TITLE
CI: fix build dir of pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
 
     - name: Cache emodb
       uses: actions/cache@v3
@@ -44,7 +46,7 @@ jobs:
     #  run: |
     #    python -m sphinx docs/ build/html -b html -W -D katex_prerender=True
 
-    - name: Deploy documentation to Github pages
+    - name: Deploy Github pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,48 +6,32 @@ on:
   pull_request:
     branches: [ main, dev ]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v2
       with:
-        fetch-depth: 2
-
-    - name: Cache emodb
-      uses: actions/cache@v3
-      with:
-        path: ~/audb
-        key: emodb-1.4.1
-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-
-    - name: Setup audb config
-      run: |
-        cp misc/audb.yaml ~/.audb.yaml
-
-    # Build the HTML pages
-    #
-    # Currently disabled,
-    # as this requires access to auglib.
-    # Instead we have commited the build dir directly.
-    #
-    #- name: Install package
-    #  run: |
-    #    python -m pip install --upgrade pip
-    #    pip install -r docs/requirements.txt
-    #
-    #- name: Build HTML pages
-    #  run: |
-    #    python -m sphinx docs/ build/html -b html -W -D katex_prerender=True
-
-    - name: Deploy Github pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./build/html
+        path: './build/html'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Pages
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main, dev ]
 
 jobs:
   build:
@@ -46,4 +48,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/build
+        publish_dir: ./build/html

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,6 @@ name: Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main, dev ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Pages are stored under `build/html/`, not `docs/build/`.