### PR TITLE
Update README statement on reproducibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,11 +19,14 @@ Results are grouped after the different model tasks:
 
 **🚨 Warning**:
 you cannot install and run the test suite at the moment.
-We will change this by open-sourcing
-the required augmentation library,
-and provide access to the data
-and models
-in the following months.
+It depends on an internal Python package
+to load all the models.
+And most of the data used in the tests
+is also hosted on internal servers.
+
+The libraries for managing the data,
+and applying the augmentations
+are available as open-source.
 
 
 .. _arousal: https://audeering.github.io/ser-tests/test/arousal.html

--- a/README.rst
+++ b/README.rst
@@ -21,13 +21,18 @@ Results are grouped after the different model tasks:
 you cannot install and run the test suite at the moment.
 It depends on an internal Python package
 to load all the models.
-And most of the data used in the tests
-is hosted on internal servers.
-The libraries for managing the data,
-and applying the augmentations
-are available as open-source.
+Most of the datasets used in the tests
+are hosted on internal servers,
+and you would need to download the datasets
+from their original sources
+and convert to audformat_
+to run the tests.
+We released the augmentation library used for the tests
+as the auglib_ Python package.
 
 
+.. _audformat: https://audeering.github.io/audformat/
+.. _auglib: https://audeering.github.io/auglib/
 .. _arousal: https://audeering.github.io/ser-tests/test/arousal.html
 .. _dominance: https://audeering.github.io/ser-tests/test/dominance.html
 .. _emotional categories: https://audeering.github.io/ser-tests/test/emotion.html

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,6 @@ It depends on an internal Python package
 to load all the models.
 And most of the data used in the tests
 is also hosted on internal servers.
-
 The libraries for managing the data,
 and applying the augmentations
 are available as open-source.

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ you cannot install and run the test suite at the moment.
 It depends on an internal Python package
 to load all the models.
 And most of the data used in the tests
-is also hosted on internal servers.
+is hosted on internal servers.
 The libraries for managing the data,
 and applying the augmentations
 are available as open-source.

--- a/build/html/index.html
+++ b/build/html/index.html
@@ -321,7 +321,7 @@
             
             
               <div class="version">
-                v4766ee97
+                vbcaaf129
               </div>
             
           
@@ -420,11 +420,14 @@ Results are grouped after the different model tasks:</p>
 you cannot install and run the test suite at the moment.
 It depends on an internal Python package
 to load all the models.
-And most of the data used in the tests
-is hosted on internal servers.
-The libraries for managing the data,
-and applying the augmentations
-are available as open-source.</p>
+Most of the datasets used in the tests
+are hosted on internal servers,
+and you would need to download the datasets
+from their original sources
+and convert to <a class="reference external" href="https://audeering.github.io/audformat/">audformat</a>
+to run the tests.
+We released the augmentation library used for the tests
+as the <a class="reference external" href="https://audeering.github.io/auglib/">auglib</a> Python package.</p>
 <div class="toctree-wrapper compound">
 </div>
 <div class="toctree-wrapper compound">

--- a/build/html/index.html
+++ b/build/html/index.html
@@ -321,7 +321,7 @@
             
             
               <div class="version">
-                v2c39464
+                v4766ee97
               </div>
             
           
@@ -418,11 +418,13 @@ Results are grouped after the different model tasks:</p>
 </ul>
 <p><strong>🚨 Warning</strong>:
 you cannot install and run the test suite at the moment.
-We will change this by open-sourcing
-the required augmentation library,
-and provide access to the data
-and models
-in the following months.</p>
+It depends on an internal Python package
+to load all the models.
+And most of the data used in the tests
+is hosted on internal servers.
+The libraries for managing the data,
+and applying the augmentations
+are available as open-source.</p>
 <div class="toctree-wrapper compound">
 </div>
 <div class="toctree-wrapper compound">


### PR DESCRIPTION
I updated the statement in the README, as `auglib` is now also opens-source:

![image](https://github.com/audeering/ser-tests/assets/173624/8c478258-5ed2-4029-811b-49de584e4430)

We should maybe also target to release all the tested models.

For the data, I think it will be too much work to provide all the conversions scripts, as for some datasets this would mean distilling the conversion of several different dataset versions into a single conversion file.