### PR TITLE
Fix links to datasets

### DIFF
--- a/build/html/method-tests.html
+++ b/build/html/method-tests.html
@@ -322,7 +322,7 @@
             
             
               <div class="version">
-                v2c39464
+                v9db2c84e
               </div>
             
           
@@ -1071,7 +1071,7 @@ which ranges from 0 to 1.</p>
 regarding the accent of a speaker.
 For now, we only investigate English accents.</p>
 <p>The investigation is based
-on the <a class="reference external" href="http://data.pp.audeering.com/databases/speech-accent-archive/speech-accent-archive.html">speech-accent-archive</a> database,
+on the <a class="reference external" href="https://www.kaggle.com/rtatman/speech-accent-archive">speech-accent-archive</a> database,
 which provides recordings
 for several different accents.
 Each speaker in the database was asked
@@ -1396,7 +1396,7 @@ If the text content has an influence
 on the model predictions,
 it should have the same influence for each
 language.</p>
-<p>We use the <a class="reference external" href="http://data.pp.audeering.com/databases/checklist-synth/checklist-synth.html">checklist-synth</a> database,
+<p>We use the checklist-synth database,
 which contains synthetic speech
 of text with sentiment-labelled
 sentences or words generated from <a class="reference external" href="https://github.com/marcotcr/checklist">checklist</a>.
@@ -2248,7 +2248,7 @@ of the <a class="reference external" href="http://www.openslr.org/17/">musan</a>
 are mixed
 and added with an SNR of 20 dB</p></li>
 <li><p>Coughing: one single cough
-from our internal <a class="reference external" href="http://data.pp.audeering.com/databases/cough-speech-sneeze/cough-speech-sneeze.html">cough-speech-sneeze</a> database
+from our internal <a class="reference external" href="https://audeering.github.io/datasets/datasets/cough-speech-sneeze.html">cough-speech-sneeze</a> database
 (based on <span id="id12">[<a class="reference internal" href="bibliography.html#id3" title="Shahin Amiriparian, Sergey Pugachevskiy, Nicholas Cummins, Simone Hantke, Jouni Pohjalainen, Gil Keren, and Björn W. Schuller. CAST a database: rapid targeted large-scale big data acquisition via small-world modelling of social media platforms. In 2017 Seventh International Conference on Affective Computing and Intelligent Interaction (ACII), 340-345. 2017. URL: https://doi.org/10.1109/ACII.2017.8273622.">APC+17</a>]</span>)
 is added to each sample
 at a random position
@@ -2276,7 +2276,7 @@ The music table includes Western art music
 (e.g. Baroque, Romantic, Classical)
 and popular genres (e.g. jazz, bluegrass, hiphop)</p></li>
 <li><p>Sneezing: one single sneeze
-from the <a class="reference external" href="http://data.pp.audeering.com/databases/cough-speech-sneeze/cough-speech-sneeze.html">cough-speech-sneeze</a> database
+from the <a class="reference external" href="https://audeering.github.io/datasets/datasets/cough-speech-sneeze.html">cough-speech-sneeze</a> database
 is added to each sample
 at a random position
 with an SNR of 10 dB</p></li>
@@ -2554,8 +2554,8 @@ In addition,
 they may show low pass behavior
 as indicated by the following plot
 showing the magnitude spectrum
-for one low quality phone sample from <a class="reference external" href="http://data.pp.audeering.com/databases/switchboard-1/switchboard-1.html">switchboard-1</a>,
-and a high quality headphone recording sample from <a class="reference external" href="http://data.pp.audeering.com/databases/emovo/emovo.html">emovo</a>.</p>
+for one low quality phone sample from <a class="reference external" href="https://catalog.ldc.upenn.edu/LDC97S62">switchboard-1</a>,
+and a high quality headphone recording sample from emovo.</p>
 <div class="figure align-default">
 <img alt="_images/method-tests-10.png" class="plot-directive" src="_images/method-tests-10.png" />
 </div>

--- a/docs/method-tests.rst
+++ b/docs/method-tests.rst
@@ -498,7 +498,7 @@ or we skip that bin.
     :file: method-tests/emotion/fairness_accent.csv
 
 
-.. _speech-accent-archive: http://data.pp.audeering.com/databases/speech-accent-archive/speech-accent-archive.html
+.. _speech-accent-archive: https://www.kaggle.com/rtatman/speech-accent-archive
 
 
 .. =======================================================================
@@ -626,7 +626,7 @@ on the model predictions,
 it should have the same influence for each
 language.
 
-We use the `checklist-synth`_ database,
+We use the checklist-synth database,
 which contains synthetic speech
 of text with sentiment-labelled
 sentences or words generated from `checklist`_.
@@ -797,7 +797,6 @@ or we skip the bin for that sentiment.
     :file: method-tests/emotion/fairness_linguistic_sentiment.csv
 
 
-.. _checklist-synth: http://data.pp.audeering.com/databases/checklist-synth/checklist-synth.html
 .. _checklist: https://github.com/marcotcr/checklist
 .. _espnet: https://github.com/espnet/espnet
 .. _TTS: https://github.com/coqui-ai/TTS
@@ -1402,7 +1401,7 @@ to compute this percentage.
 
 
 .. _musan: http://www.openslr.org/17/
-.. _cough-speech-sneeze: http://data.pp.audeering.com/databases/cough-speech-sneeze/cough-speech-sneeze.html
+.. _cough-speech-sneeze: https://audeering.github.io/datasets/datasets/cough-speech-sneeze.html
 
 
 .. _method-test-robustness-low-quality-phone:
@@ -1420,7 +1419,7 @@ they may show low pass behavior
 as indicated by the following plot
 showing the magnitude spectrum
 for one low quality phone sample from switchboard-1_,
-and a high quality headphone recording sample from emovo_.
+and a high quality headphone recording sample from emovo.
 
 .. Prepare helper functions
 .. plot::
@@ -1662,8 +1661,7 @@ to compute this percentage.
     :file: method-tests/emotion/robustness_low_quality_phone.csv
 
 
-.. _emovo: http://data.pp.audeering.com/databases/emovo/emovo.html
-.. _switchboard-1: http://data.pp.audeering.com/databases/switchboard-1/switchboard-1.html
+.. _switchboard-1: https://catalog.ldc.upenn.edu/LDC97S62
 
 
 .. =======================================================================


### PR DESCRIPTION
Updates links for datasets in the method section to no longer point towards our internal data.pp.audeering.com address, but to the original URL of the data. If no URL is available I removed the link.